### PR TITLE
Monotonic clock time

### DIFF
--- a/lib/uuid7.rb
+++ b/lib/uuid7.rb
@@ -17,7 +17,7 @@ module UUID7
   #
   # @param timestamp [Integer] the timestamp to use for UUID v7
   # @return [String] the generated UUID v7 string
-  def self.generate(timestamp: Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
+  def self.generate(timestamp: Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond))
     format("%08x-%04x-%04x-%04x-%04x%08x", *Generator.generate(timestamp))
   end
 end


### PR DESCRIPTION
Using monotonic time ensures the timestamp always increments and doesn't jump backwards due to changes like the introduction of leap seconds